### PR TITLE
Camera unfreeze on Scene Startup

### DIFF
--- a/Prototype1/Assets/Scripts/SceneController.cs
+++ b/Prototype1/Assets/Scripts/SceneController.cs
@@ -9,7 +9,8 @@ public class SceneController : MonoBehaviour
     // Start is called before the first frame update
     void Start()
     {
-        
+        CameraController.lookSpeed = 1.0f;
+        BodyController.lookSpeed = 1.0f;
     }
 
     // Update is called once per frame


### PR DESCRIPTION
- Fixed Paralysis bug where player stays paralyzed when scene changes